### PR TITLE
added NodeLocation.extra['networking_type'] to describe the MCP version

### DIFF
--- a/libcloud/compute/base.py
+++ b/libcloud/compute/base.py
@@ -394,7 +394,7 @@ class NodeLocation(object):
     'US'
     """
 
-    def __init__(self, id, name, country, driver):
+    def __init__(self, id, name, country, driver, extra=None):
         """
         :param id: Location ID.
         :type id: ``str``
@@ -407,11 +407,16 @@ class NodeLocation(object):
 
         :param driver: Driver this location belongs to.
         :type driver: :class:`.NodeDriver`
+
+        :param extra: Optional provided specific attributes associated with
+                      this NodeLocation.
+        :type extra: ``dict``
         """
         self.id = str(id)
         self.name = name
         self.country = country
         self.driver = driver
+        self.extra = extra or {}
 
     def __repr__(self):
         return (('<NodeLocation: id=%s, name=%s, country=%s, driver=%s>')

--- a/libcloud/compute/drivers/dimensiondata.py
+++ b/libcloud/compute/drivers/dimensiondata.py
@@ -2565,10 +2565,12 @@ class DimensionDataNodeDriver(NodeDriver):
         return locations
 
     def _to_location(self, element):
+        networking = element.find(fixxpath('networking', TYPES_URN))
         l = NodeLocation(id=element.get('id'),
                          name=findtext(element, 'displayName', TYPES_URN),
                          country=findtext(element, 'country', TYPES_URN),
-                         driver=self)
+                         driver=self,
+                         extra={'networking_type': networking.get('type')})
         return l
 
     def _to_cpu_spec(self, element):

--- a/libcloud/compute/drivers/dimensiondata.py
+++ b/libcloud/compute/drivers/dimensiondata.py
@@ -2566,12 +2566,11 @@ class DimensionDataNodeDriver(NodeDriver):
 
     def _to_location(self, element):
         networking = element.find(fixxpath('networking', TYPES_URN))
-        l = NodeLocation(id=element.get('id'),
-                         name=findtext(element, 'displayName', TYPES_URN),
-                         country=findtext(element, 'country', TYPES_URN),
-                         driver=self,
-                         extra={'networking_type': networking.get('type')})
-        return l
+        return NodeLocation(id=element.get('id'),
+                            name=findtext(element, 'displayName', TYPES_URN),
+                            country=findtext(element, 'country', TYPES_URN),
+                            driver=self,
+                            extra={'networking_type': networking.get('type')})
 
     def _to_cpu_spec(self, element):
         return DimensionDataServerCpuSpecification(

--- a/libcloud/test/compute/test_dimensiondata.py
+++ b/libcloud/test/compute/test_dimensiondata.py
@@ -849,6 +849,10 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
         location = self.driver.ex_get_location_by_id(None)
         self.assertIsNone(location)
 
+    def test_ex_get_location_extra_network_type(self):
+        location = self.driver.ex_get_location_by_id('NA9')
+        self.assertEqual(location.extra['networking_type'], '2')
+
     def test_ex_get_base_image_by_id(self):
         image_id = self.driver.list_images()[0].id
         image = self.driver.ex_get_base_image_by_id(image_id)


### PR DESCRIPTION
## Add NodeLocation.extra['networking_type'] to display MCP version
### Description

Added and extra attribute to NodeLocation to include networking_type.  This gives the ability for libcloud to query the MCP version of a given location.
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
